### PR TITLE
iOS Support 

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,14 @@
   "private": true,
   "scripts": {
     "dev": "run-p webpack:watch cordova:serve",
+    "add:browser": "cordova platform add browser",
     "webpack:watch": "webpack --mode=development",
     "cordova:serve": "phonegap serve",
     "build:react": "webpack --mode=production",
+    "add:ios": "cordova platform add ios",
+    "run:ios": "cordova run ios",
+    "build:ios": "cordova run ios",
+    "add:android": "cordova platform add android",
     "run:android": "cordova run android",
     "build:android:debug": "cordova build android",
     "build:android:release": "cordova build android --release -- --keystore=./{keysotrename}.keystore --storePassword={keystorePassword}  --alias={key alias name} --password={key password}"


### PR DESCRIPTION
### Adding scripts to support ios builds and also browser testing with cordova default plugins.
This will enable people to test in virtual env. and also physical env (via adb or xcode);


If anyone can test on ios physical env, it would be great.

resolves #1